### PR TITLE
解决日志目录不存在报错NullPointException问题

### DIFF
--- a/datarangers-sdk-core/pom.xml
+++ b/datarangers-sdk-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datarangers-sdk</artifactId>
         <groupId>com.datarangers</groupId>
-        <version>1.5.8-release</version>
+        <version>1.5.9-release</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/datarangers-sdk-core/src/main/java/com/datarangers/config/Constants.java
+++ b/datarangers-sdk-core/src/main/java/com/datarangers/config/Constants.java
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.GregorianCalendar;
 
 public class Constants {
-    public static final String SDK_VERSION = "datarangers_sdk_1.5.8-release";
+    public static final String SDK_VERSION = "datarangers_sdk_1.5.9-release";
     public static DateTimeFormatter FULL_HOUR = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH");
     public static DateTimeFormatter FULL_DAY = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     public static final String APP_LOG_PATH = "/sdk/log";

--- a/datarangers-sdk-example/pom.xml
+++ b/datarangers-sdk-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datarangers-sdk</artifactId>
         <groupId>com.datarangers</groupId>
-        <version>1.5.8-release</version>
+        <version>1.5.9-release</version>
     </parent>
     <groupId>com.datarangers</groupId>
     <artifactId>datarangers-sdk-example</artifactId>

--- a/datarangers-sdk-starter/pom.xml
+++ b/datarangers-sdk-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.datarangers</groupId>
         <artifactId>datarangers-sdk</artifactId>
-        <version>1.5.8-release</version>
+        <version>1.5.9-release</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>datarangers-sdk-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.datarangers</groupId>
     <artifactId>datarangers-sdk</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.8-release</version>
+    <version>1.5.9-release</version>
     <modules>
         <module>datarangers-sdk-core</module>
         <module>datarangers-sdk-starter</module>


### PR DESCRIPTION
- 服务器上没有默认日志目录 /logs 时，项目会启动失败并报错空异常。

- 修改了RangersLoggerWriter.setCurrentIndex方法，如果没有目录时的创建逻辑以及创建失败的异常处理，方便使用时定位问题。